### PR TITLE
Add support for alpha modifier in token mappings

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -70,11 +70,18 @@ const hexToRGB = (str) => {
 }
 
 export const toCSSMap = ([k, v], duplicateAsRgb) => {
-  let css = `${tokenKey(k)} var(--w-${v});`;
-  if (duplicateAsRgb) {
-    const rgbTokenKey = tokenKey(k.replace(/^(s-)?(color-)?(.*)/, '$1rgb-$3'));
-    const rgbTokenValue = `var(--w-${v.replace(/^(s-)?(color-)?(.*)/, '$1rgb-$3')});`;
-    css = css.concat(rgbTokenKey, rgbTokenValue);
+  let css = `${tokenKey(k)}`;
+  const alpha = v.match(/([^\/]+)\/(0|[1-9][0-9]?|100)$/);
+  if (alpha) {
+    const decimalAlpha = (parseFloat(alpha[2]) / 100).toString().replace(/^0\./, '.');
+    css += `rgba(var(--w-${alpha[1].replace(/^(s-)?(color-)?(.*)/, '$1rgb-$3')}),${decimalAlpha});`;
+  } else {
+    css += `var(--w-${v});`;
+    if (duplicateAsRgb) {
+      const rgbTokenKey = tokenKey(k.replace(/^(s-)?(color-)?(.*)/, '$1rgb-$3'));
+      const rgbTokenValue = `var(--w-${v.replace(/^(s-)?(color-)?(.*)/, '$1rgb-$3')});`;
+      css = css.concat(rgbTokenKey, rgbTokenValue);
+    }
   }
   return css;
 }


### PR DESCRIPTION
This will make it possible to add alpha channel modifiers to the token mappings:
![image](https://github.com/warp-ds/tokenizer/assets/7531505/aa4f936c-6aad-4c12-88ea-52fd9c80ea3f)
which will result in this css:
![image](https://github.com/warp-ds/tokenizer/assets/7531505/e8cec025-2edf-4ae2-a37f-ee8fd9ffe7b1)
